### PR TITLE
Handle unhandled exceptions in WarmUp()

### DIFF
--- a/src/WinGetCommandNotFoundFeedbackPredictor.cs
+++ b/src/WinGetCommandNotFoundFeedbackPredictor.cs
@@ -53,6 +53,7 @@ namespace Microsoft.WinGet.CommandNotFound
             finally
             {
                 _pool.Return(ps);
+                _warmedUp = true;
             }
         }
 

--- a/src/WinGetCommandNotFoundFeedbackPredictor.cs
+++ b/src/WinGetCommandNotFoundFeedbackPredictor.cs
@@ -23,8 +23,6 @@ namespace Microsoft.WinGet.CommandNotFound
 
         private List<string> _candidates = new List<string>();
 
-        private bool _warmedUp;
-
         private WinGetCommandNotFoundFeedbackPredictor()
         {
             var provider = new DefaultObjectPoolProvider();
@@ -49,10 +47,10 @@ namespace Microsoft.WinGet.CommandNotFound
                     .AddParameter("Count", 1)
                     .InvokeAsync();
             }
+            catch (Exception /*ex*/) {}
             finally
             {
                 _pool.Return(ps);
-                _warmedUp = true;
             }
         }
 
@@ -145,14 +143,6 @@ namespace Microsoft.WinGet.CommandNotFound
 
         private Collection<PSObject> FindPackages(string query, ref bool tooManySuggestions, ref string packageMatchFilterField)
         {
-            if (!_warmedUp)
-            {
-                // Given that the warm-up was not done, it's no good to carry on because we
-                // will likely get a newly created PowerShell object
-                // and pay the same overhead of the warmup method.
-                return new Collection<PSObject>();
-            }
-
             var ps = _pool.Get();
             try
             {

--- a/src/WinGetCommandNotFoundFeedbackPredictor.cs
+++ b/src/WinGetCommandNotFoundFeedbackPredictor.cs
@@ -23,6 +23,8 @@ namespace Microsoft.WinGet.CommandNotFound
 
         private List<string> _candidates = new List<string>();
 
+        private bool _warmedUp;
+
         private WinGetCommandNotFoundFeedbackPredictor()
         {
             var provider = new DefaultObjectPoolProvider();
@@ -143,6 +145,14 @@ namespace Microsoft.WinGet.CommandNotFound
 
         private Collection<PSObject> FindPackages(string query, ref bool tooManySuggestions, ref string packageMatchFilterField)
         {
+            if (!_warmedUp)
+            {
+                // Given that the warm-up was not done, it's no good to carry on because we
+                // will likely get a newly created PowerShell object
+                // and pay the same overhead of the warmup method.
+                return new Collection<PSObject>();
+            }
+
             var ps = _pool.Get();
             try
             {


### PR DESCRIPTION
`WarmUp()` asynchronously calls `Find-WinGetPackage` when the module is imported to pre-load the WinGet database so that future calls are faster.

For #8, a `PipelineStoppedException` would occur when the user `exit`s or `^C` during that async call.
For #9, a `CmdletInvocationException` would occur from `Microsoft.WinGet.Client` failing to create some WinGet objects. 

We're normally able to handle an exception [here](https://github.com/microsoft/winget-command-not-found/blob/53257430d380fd02a0b36ca1a86e77e348feaaa8/src/WinGetCommandNotFoundFeedbackPredictor.cs#L140-L143), but we don't actually have any error handling in `WarmUp()`. This just adds a catch there.

Though we don't actually do anything with the error there, here's what's expected from the situations encountered:
- `PipelineStoppedException` from `exit`: exception is caught and the user exited the session, so we silently didn't warm up and that's fine
- `PipelineStoppedException` from `^C`: exception is caught and warm up is cancelled. `_warmedUp` is still set to `true` so we'll just load the WinGet db on first run
- `CmdletInvocationException`: unsure why WinGet wasn't able to connect, but we handle the exception here and silently continue. When the feedback provider is used again, if we get an exception, we present the error from [here](https://github.com/microsoft/winget-command-not-found/blob/53257430d380fd02a0b36ca1a86e77e348feaaa8/src/WinGetCommandNotFoundFeedbackPredictor.cs#L140-L143).

Closes #7 
Closes #8 
Closes #9