### PR TITLE
Fix additional results message

### DIFF
--- a/src/WinGetCommandNotFoundFeedbackPredictor.cs
+++ b/src/WinGetCommandNotFoundFeedbackPredictor.cs
@@ -136,7 +136,7 @@ namespace Microsoft.WinGet.CommandNotFound
 
                 // Build footer message
                 var footerMessage = tooManySuggestions ?
-                    string.Format(CultureInfo.InvariantCulture, "Additional results can be found using \"winget search --command {1}\"", target) :
+                    string.Format(CultureInfo.InvariantCulture, "Additional results can be found using \"winget search --command {0}\"", target) :
                     null;
 
                 return new FeedbackItem(


### PR DESCRIPTION
The wrong index is used to interpolate the "additional results" message, causing a confusing error when a command matches to many packages.

**Before:**
<img width="600" alt="WinGet Command Not Found returning '0' as the error message when ffmpeg is run" src="https://github.com/user-attachments/assets/6d7c0de4-0d4e-450d-9a17-02890a8dca26" />

**After:**
<img width="600" alt="WinGet Command Not Found with additional results message after ffmpeg is run" src="https://github.com/user-attachments/assets/a8797663-20a9-467e-85a6-1ada35477dc1" />
