### PR TITLE
Add policy bot rules for issue and PR management

### DIFF
--- a/.github/policies/labelAdded.noRecentActivity.yml
+++ b/.github/policies/labelAdded.noRecentActivity.yml
@@ -1,0 +1,50 @@
+id: labelAdded.noRecentActivity
+name: GitOps.PullRequestIssueManagement
+description: Handlers when "No-Recent-Activity" label is added
+owner:
+resource: repository
+disabled: false
+where:
+configuration:
+  resourceManagementConfiguration:
+    eventResponderTasks:
+      - description: >-
+          When the label "No-Recent-Activity" is added to a pull request
+          * Add the PR specific reply notifying the issue author of pending closure
+        if:
+          - payloadType: Pull_Request
+          - labelAdded:
+              label: No-Recent-Activity
+        then:
+          - addReply:
+              reply: >-
+                Hello @${issueAuthor},
+
+
+                This pull request has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **7 days**. It will be closed if no further activity occurs **within 7 days of this comment**.
+
+
+                Template: msftbot/noRecentActivity
+        # The policy service should trigger even when the label was added by the policy service
+        triggerOnOwnActions: true
+      - description: >-
+          When the label "No-Recent-Activity" is added to an issue
+          * Add the issue specific reply notifying the issue author of pending closure
+        if:
+          - payloadType: Issues
+          - labelAdded:
+              label: No-Recent-Activity
+        then:
+          - addReply:
+              reply: >-
+                Hello @${issueAuthor},
+
+
+                This issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **7 days**. It will be closed if no further activity occurs **within 7 days of this comment**.
+
+
+                Template: msftbot/noRecentActivity
+        # The policy service should trigger even when the label was added by the policy service
+        triggerOnOwnActions: true
+onFailure:
+onSuccess:

--- a/.github/policies/labelManagement.issueClosed.yml
+++ b/.github/policies/labelManagement.issueClosed.yml
@@ -1,0 +1,36 @@
+id: labelManagement.issueClosed
+name: GitOps.PullRequestIssueManagement
+description: Handlers when an issue gets closed
+owner:
+resource: repository
+disabled: false
+where:
+configuration:
+  resourceManagementConfiguration:
+    eventResponderTasks:
+      - description: Remove labels when an issue is closed
+        if:
+          - payloadType: Issues
+          - isAction:
+              action: Closed
+        then:
+          - removeLabel:
+              label: Needs-Triage
+          - removeLabel:
+              label: Needs-Attention
+          - removeLabel:
+              label: Needs-Author-Feedback
+          - removeLabel:
+              label: Help-Wanted
+      - description: Remove labels when a pull request is closed
+        if:
+          - payloadType: Pull_Request
+          - isAction:
+              action: Closed
+        then:
+          - removeLabel:
+              label: Needs-Attention
+          - removeLabel:
+              label: Needs-Author-Feedback
+onFailure:
+onSuccess:

--- a/.github/policies/labelManagement.issueOpened.yml
+++ b/.github/policies/labelManagement.issueOpened.yml
@@ -1,0 +1,27 @@
+id: labelManagement.issueOpened
+name: GitOps.PullRequestIssueManagement
+description: Handlers for when an issue is first opened
+owner:
+resource: repository
+disabled: false
+where:
+configuration:
+  resourceManagementConfiguration:
+    eventResponderTasks:
+      - description: Add CodeFlow link to new PRs
+        if:
+          - payloadType: Pull_Request
+          - isAction:
+              action: Opened
+        then:
+          - addCodeFlowLink
+      - description: Add Needs-Triage to new issues
+        if:
+          - payloadType: Issues
+          - isAction:
+              action: Opened
+        then:
+          - addLabel:
+              label: Needs-Triage
+onFailure:
+onSuccess:

--- a/.github/policies/labelManagement.issueUpdated.yml
+++ b/.github/policies/labelManagement.issueUpdated.yml
@@ -1,0 +1,95 @@
+id: labelManagement.issueUpdated
+name: GitOps.PullRequestIssueManagement
+description: >-
+  Handlers for when an issue is updated and not closed
+  This primarily includes handlers for comments, reviews, and re-runs
+owner:
+resource: repository
+disabled: false
+where:
+configuration:
+  resourceManagementConfiguration:
+    eventResponderTasks:
+      - description: Remove "No-Recent-Activity" when a pull request or issue is updated
+        if:
+          - or:
+              - payloadType: Pull_Request
+              - payloadType: Pull_Request_Review
+              - payloadType: Pull_Request_Review_Comment
+              - payloadType: Issue_Comment
+              - payloadType: Issues
+          - not:
+              isAction:
+                action: Closed
+          - hasLabel:
+              label: No-Recent-Activity
+        then:
+          - removeLabel:
+              label: No-Recent-Activity
+        # The policy service should not trigger itself here, or else the label would be removed immediately after being added
+        triggerOnOwnActions: False
+      - description: Clean email replies on every comment
+        if:
+          - or:
+              - payloadType: Issue_Comment
+              - payloadType: Pull_Request_Review_Comment
+        then:
+          - cleanEmailReply
+      - description: Remove "Help-Wanted" label when an issue goes into PR
+        if:
+          - payloadType: Issues
+          - labelAdded:
+              label: In-PR
+          - hasLabel:
+              label: Help-Wanted
+        then:
+          - removeLabel:
+              label: Help-Wanted
+      - description: >-
+          If an author responds to an issue which needs author feedback
+          * Remove the Needs-Author-Feedback Label
+          * Add the Needs-Attention Label
+        if:
+          - or:
+              - payloadType: Pull_Request_Review
+              - payloadType: Pull_Request_Review_Comment
+              - payloadType: Issue_Comment
+          - isActivitySender:
+              issueAuthor: True
+          - hasLabel:
+              label: Needs-Author-Feedback
+          - not:
+              isAction:
+                action: Synchronize
+        then:
+          - removeLabel:
+              label: Needs-Author-Feedback
+          - addLabel:
+              label: Needs-Attention
+      - description: >-
+          When changes are requested on a pull request
+          * Disable automerge
+          * Assign to the author
+          * Label with Needs-Author-Feedback
+        if:
+          - payloadType: Pull_Request_Review
+          - isAction:
+              action: Submitted
+          - isReviewState:
+              reviewState: Changes_requested
+        then:
+          - disableAutoMerge
+          - assignTo:
+              author: True
+          - addLabel:
+              label: Needs-Author-Feedback
+      - description: Sync labels from issues on all pull request events
+        if:
+          - payloadType: Pull_Request
+        then:
+          - labelSync:
+              pattern: Issue-
+          - inPrLabel:
+              label: In-PR
+onFailure:
+onSuccess:

--- a/.github/policies/labelManagement.triageLabels.yml
+++ b/.github/policies/labelManagement.triageLabels.yml
@@ -1,0 +1,41 @@
+id: labelAdded.triageLabels
+name: GitOps.PullRequestIssueManagement
+description: Handlers for triaging issues when various labels are applied from Triage
+owner:
+resource: repository
+disabled: false
+where:
+configuration:
+  resourceManagementConfiguration:
+    eventResponderTasks:
+      - description: >-
+          When specific labels are added to an issue
+          * Remove the Needs-Triage label
+        if:
+          - payloadType: Issues
+          - or:
+              - labelAdded:
+                  label: Issue-Bug
+              - labelAdded:
+                  label: Issue-Feature
+              - labelAdded:
+                  label: Issue-Docs
+              - labelAdded:
+                  label: Needs-Attention
+              - labelAdded:
+                  label: Needs-Author-Feedback
+              - labelAdded:
+                  label: In-PR
+              - labelAdded:
+                  label: Help-Wanted
+              - labelAdded:
+                  label: Blocking-Issue
+              - labelAdded:
+                  label: Resolution-Duplicate
+        then:
+          - removeLabel:
+              label: Needs-Triage
+        # The policy service should trigger even when the label was added by the policy service
+        triggerOnOwnActions: true
+onFailure:
+onSuccess:

--- a/.github/policies/scheduledSearch.closeNoRecentActivity.yml
+++ b/.github/policies/scheduledSearch.closeNoRecentActivity.yml
@@ -1,0 +1,67 @@
+id: scheduledSearch.closeNoRecentActivity
+name: GitOps.PullRequestIssueManagement
+description: Closes issues that are inactive
+owner:
+resource: repository
+disabled: false
+where:
+configuration:
+  resourceManagementConfiguration:
+    scheduledSearches:
+      - description: >-
+          Search for PR where -
+          * Pull Request is Open
+          * Pull request has the label No-Recent-Activity
+          * Pull request has the label Needs-Author-Feedback
+          * Pull request does not have the label Blocking-Issue
+          * Has not had activity in the last 7 days
+
+          Then -
+          * Close the PR
+        frequencies:
+          - hourly:
+              hour: 6
+        filters:
+          - isPullRequest
+          - isOpen
+          - hasLabel:
+              label: No-Recent-Activity
+          - hasLabel:
+              label: Needs-Author-Feedback
+          - isNotLabeledWith:
+              label: Blocking-Issue
+          - noActivitySince:
+              days: 7
+        actions:
+          - closeIssue
+      - description: >-
+          Search for Issues where -
+          * Issue is Open
+          * Issue has the label No-Recent-Activity
+          * Issue has the label Needs-Author-Feedback
+          * Issue does not have the label Blocking-Issue
+          * Issue does not have the label Issue-Feature
+          * Has not had activity in the last 7 days
+
+          Then -
+          * Close the Issue
+        frequencies:
+          - hourly:
+              hour: 6
+        filters:
+          - isIssue
+          - isOpen
+          - hasLabel:
+              label: No-Recent-Activity
+          - hasLabel:
+              label: Needs-Author-Feedback
+          - isNotLabeledWith:
+              label: Blocking-Issue
+          - isNotLabeledWith:
+              label: Issue-Feature
+          - noActivitySince:
+              days: 7
+        actions:
+          - closeIssue
+onFailure:
+onSuccess:

--- a/.github/policies/scheduledSearch.markNoRecentActivity.yml
+++ b/.github/policies/scheduledSearch.markNoRecentActivity.yml
@@ -1,0 +1,69 @@
+id: scheduledSearch.markNoRecentActivity
+name: GitOps.PullRequestIssueManagement
+description: Marks issues that are inactive
+owner:
+resource: repository
+disabled: false
+where:
+configuration:
+  resourceManagementConfiguration:
+    scheduledSearches:
+      - description: >-
+          Search for PR where -
+          * Pull Request is Open
+          * Pull request does not have the label No-Recent-Activity
+          * Pull request does not have the label Blocking-Issue
+          * Pull request has the label Needs-Author-Feedback
+          * Has not had activity in the last 7 days
+
+          Then -
+          * Add No-Recent-Activity label
+        frequencies:
+          - hourly:
+              hour: 6
+        filters:
+          - isPullRequest
+          - isOpen
+          - isNotLabeledWith:
+              label: No-Recent-Activity
+          - isNotLabeledWith:
+              label: Blocking-Issue
+          - hasLabel:
+              label: Needs-Author-Feedback
+          - noActivitySince:
+              days: 7
+        actions:
+          - addLabel:
+              label: No-Recent-Activity
+      - description: >-
+          Search for Issues where -
+          * Issue is Open
+          * Issue has the label Needs-Author-Feedback
+          * Issue does not have the label No-Recent-Activity
+          * Issue does not have the label Blocking-Issue
+          * Issue does not have the label Issue-Feature
+          * Has not had activity in the last 7 days
+
+          Then -
+          * Mark the Issue with No-Recent-Activity
+        frequencies:
+          - hourly:
+              hour: 6
+        filters:
+          - isIssue
+          - isOpen
+          - hasLabel:
+              label: Needs-Author-Feedback
+          - isNotLabeledWith:
+              label: No-Recent-Activity
+          - isNotLabeledWith:
+              label: Blocking-Issue
+          - isNotLabeledWith:
+              label: Issue-Feature
+          - noActivitySince:
+              days: 7
+        actions:
+          - addLabel:
+              label: No-Recent-Activity
+onFailure:
+onSuccess:


### PR DESCRIPTION
## 🔧 Changes

Add fabricbot policy rules adapted from winget-cli for automated issue and PR lifecycle management.

### Policy files added

| File | Purpose |
|------|---------|
| \labelAdded.noRecentActivity.yml\ | Notify authors when issues/PRs are marked stale |
| \labelManagement.issueClosed.yml\ | Clean up workflow labels when issues/PRs close |
| \labelManagement.issueOpened.yml\ | Add Needs-Triage to new issues, CodeFlow links to PRs |
| \labelManagement.issueUpdated.yml\ | Activity tracking, author feedback flow, label sync, In-PR |
| \labelManagement.triageLabels.yml\ | Remove Needs-Triage when triage labels are applied |
| \scheduledSearch.closeNoRecentActivity.yml\ | Auto-close stale issues/PRs after 7+7 days |
| \scheduledSearch.markNoRecentActivity.yml\ | Mark stale issues/PRs with No-Recent-Activity |

### Labels created

The following labels were created to support these policies:
\Needs-Triage\, \Needs-Attention\, \Needs-Author-Feedback\, \No-Recent-Activity\, \In-PR\, \Help-Wanted\, \Blocking-Issue\, \Issue-Docs\, \Resolution-Duplicate\

### Differences from winget-cli

- No moderator triggers (no moderators for this project)
- No Feedback Hub integration (not applicable for this module)
- No localization file detection (not applicable)
- No area/command auto-labeling (simpler project scope)
- Simplified label sync (Issue- pattern only)

## 📋 Issue Type

- [x] Policy / Automation