### PR TITLE
Add issue templates with Issue Types

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_Report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.yml
@@ -1,0 +1,52 @@
+name: '🐛 Bug Report'
+description: Report errors or unexpected behavior.
+type: Bug
+labels:
+- Issue-Bug
+- Needs-Triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > This bug tracker is monitored by the Windows Package Manager development team and other technical folks.
+        >
+        > **Important: When reporting security issues, DO NOT attach memory dumps, logs, or traces to GitHub issues**.
+        > Instead, send dumps/traces to secure@microsoft.com, referencing this GitHub issue.
+        >
+        > Please use this form and describe your issue, concisely but precisely, with as much detail as possible.
+  - type: textarea
+    attributes:
+      label: Brief description of your issue
+      placeholder: Briefly describe your issue here.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Steps to reproduce
+      placeholder: A description of how to trigger this bug.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected behavior
+      placeholder: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Actual behavior
+      placeholder: What is currently happening?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Environment
+      placeholder: |
+        PowerShell version ($PSVersionTable.PSVersion)
+        Module version (Get-Module WinGetCommandNotFound -ListAvailable)
+        Windows version
+
+        Any other relevant software?
+      render: shell
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/Documentation_Issue.yml
+++ b/.github/ISSUE_TEMPLATE/Documentation_Issue.yml
@@ -1,0 +1,13 @@
+name: '📚 Documentation Issue'
+description: Report issues in our documentation.
+type: Task
+labels:
+- Issue-Docs
+- Needs-Triage
+body:
+  - type: textarea
+    attributes:
+      label: Brief description of your issue
+      placeholder: Briefly describe which document needs to be corrected and why.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/Feature_Request.yml
+++ b/.github/ISSUE_TEMPLATE/Feature_Request.yml
@@ -1,0 +1,21 @@
+name: '🚀 Feature Request / Idea'
+description: Suggest a new feature or improvement (this does not mean you have to implement it).
+type: Feature
+labels:
+- Issue-Feature
+- Needs-Triage
+body:
+  - type: textarea
+    attributes:
+      label: Description of the new feature / enhancement
+      placeholder: |
+        A clear and concise description of what the problem is that the new feature would solve.
+        Describe why and how a user would use this new functionality (if applicable).
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Proposed technical implementation details
+      placeholder: A clear and concise description of what you want to happen.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: General Question
+    url: https://github.com/microsoft/winget-command-not-found/discussions/new
+    about: Have a question on something? Start a new discussion thread.
+  - name: Review open issues
+    url: https://github.com/microsoft/winget-command-not-found/issues
+    about: Please check if your issue or a similar issue has already been submitted.
+  - name: WinGet CLI issues
+    url: https://github.com/microsoft/winget-cli/issues
+    about: For issues related to the WinGet client itself, please report them here.


### PR DESCRIPTION
## 🔧 Changes

Add structured issue templates for consistent issue reporting, aligned with the pattern used across other winget-* repositories.

### Templates added

| Template | Issue Type | Labels |
|----------|-----------|--------|
| Bug Report 🐛 | Bug | \Issue-Bug\, \Needs-Triage\ |
| Feature Request 🚀 | Feature | \Issue-Feature\, \Needs-Triage\ |
| Documentation Issue 📚 | Task | \Issue-Docs\, \Needs-Triage\ |

### config.yml

- Blank issues enabled
- Contact links to discussions, existing issues, and winget-cli issues

### Adapted from winget-cli / winget-create

- Bug report environment section asks for PowerShell version and module version (instead of \winget --info\)
- No area/command dropdowns (simpler project scope)
- All templates use GitHub Issue Types (\	ype:\ field)

## 📋 Issue Type

- [x] Policy / Automation